### PR TITLE
Nanosecond timestamps

### DIFF
--- a/client.go
+++ b/client.go
@@ -150,7 +150,7 @@ func (c *realClient) submit(
 	m := pb.Metric{
 		Name:         name,
 		Labels:       labels,
-		Ts:           time.Now().UTC().Unix(),
+		Ts:           time.Now().UTC().UnixNano(),
 		Aggregations: agg}
 
 	switch v := value.(type) {

--- a/pb/metrics.proto
+++ b/pb/metrics.proto
@@ -22,6 +22,7 @@ enum Agg {
 message Metric {
   string name = 1;
   map<string, string> labels = 2;
+  // Timestamp in nanoseconds since 1970
   int64 ts = 3;
   repeated Agg aggregations = 4;
   oneof Value {

--- a/plugins/graphite.go
+++ b/plugins/graphite.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fluxio/metricd/pb"
 	"github.com/fluxio/logging"
+	"github.com/fluxio/metricd/pb"
 
 	"github.com/marpaia/graphite-golang"
 )
@@ -139,7 +139,11 @@ func (g *Graphite) Run() {
 	go g.flusher()
 
 	for m := range g.Metrics {
-		g.sendToGraphite(buildGraphiteName(m), m.ValueAsString(), m.Ts)
+		g.sendToGraphite(
+			buildGraphiteName(m),
+			m.ValueAsString(),
+			m.Ts/int64(time.Second/time.Nanosecond), /* Convert nanoseconds to seconds */
+		)
 	}
 }
 

--- a/plugins/influxdb/influxdb.go
+++ b/plugins/influxdb/influxdb.go
@@ -98,7 +98,7 @@ func buildPoint(m *pb.Metric) client.Point {
 		Fields: map[string]interface{}{
 			"value": m.ValueAsFloat(),
 		},
-		Time: time.Unix(m.Ts, 0),
+		Time: time.Unix(0, m.Ts),
 	}
 }
 

--- a/server/histogram-aggregator.go
+++ b/server/histogram-aggregator.go
@@ -39,7 +39,7 @@ func (a *histAggregator) GetAggregations() []*pb.Metric {
 				Name:   a.name + "_p" + strconv.Itoa(int(q)),
 				Labels: a.labels,
 				Value:  &pb.Metric_DoubleValue{float64(a.h.ValueAtQuantile(q))},
-				Ts:     time.Now().Unix(),
+				Ts:     time.Now().UnixNano(),
 			})
 		}
 		// No point of keeping an empty histogram around, it can be large.


### PR DESCRIPTION
On the client side, generate timestamps with nanosecond precision.
On the protocol side, Metric.ts is now in nanoseconds instead of
seconds.
On the server side, send timestamps to influxdb in nanoseconds. For
graphite I'm keeping things as seconds.
